### PR TITLE
Dev

### DIFF
--- a/InstructionX_UIKit/__init__.py
+++ b/InstructionX_UIKit/__init__.py
@@ -32,7 +32,7 @@ from .tokens import (
 )
 from .icons import get_icon, ICON_NAMES
 
-__version__ = "alpha-v1.0.0"
+__version__ = "alpha-v1.0.1"
 
 __all__ = [
     "__version__",

--- a/InstructionX_UIKit/blueprint/canvas.py
+++ b/InstructionX_UIKit/blueprint/canvas.py
@@ -14,20 +14,24 @@
 - 边：hover 加粗、点击选中、running 路径 flowing 虚线动画；
 - 序列化：``to_dict`` / ``from_dict``（含节点位置与画布 zoom/offset）。
 
-节点为真实子控件（``NodeWidget``），边与临时线由画布统一自绘。
+节点为真实子控件（``NodeWidget``，挂在内部绘制视口之下）；边、临时线、
+网格、选中发光由视口统一自绘——GL 可用时视口为 ``QOpenGLWidget``
+（GPU 加速），否则为普通 ``QWidget`` 软件回退（见 ``viewport.py``，
+可用 ``UIKIT_BLUEPRINT_GL=off`` 强制软件路径）。
 """
 
-from PySide6.QtCore import QEvent, QPoint, QPointF, QRect, QRectF, Qt, QTimer, Signal
-from PySide6.QtGui import QColor, QPainter, QPainterPath, QPen
+from PySide6.QtCore import QEvent, QPoint, QPointF, QRect, QRectF, QSizeF, Qt, QTimer, Signal
+from PySide6.QtGui import QBrush, QColor, QPainter, QPainterPath, QPen, QPixmap
 from PySide6.QtWidgets import QWidget
 
 from ..theme import T, ThemeManager
-from .edge_widget import EdgeWidget, TempWire
+from .edge_widget import EdgeWidget, TempWire, bezier_path
 from .execution import ExecutionController
 from .menu import NodeContextMenu, NodeCreationMenu
 from .model import BlueprintGraph, BlueprintNode, PinDirection, types_compatible
 from .node_widget import NodeWidget, PinHandle, safe_slot
 from .registry import NodeRegistry
+from .viewport import create_viewport
 
 __all__ = ["BlueprintCanvas"]
 
@@ -37,6 +41,8 @@ ZOOM_MIN, ZOOM_MAX = 0.25, 2.5
 MAGNET_R = 22.0
 #: 右键抬起判定为点击的位移阈值（px）
 CLICK_TOL = 4.0
+#: 背景网格点半径（视图像素）
+GRID_DOT_R = 1.3
 
 
 class BlueprintCanvas(QWidget):
@@ -81,6 +87,10 @@ class BlueprintCanvas(QWidget):
         self._selected_nodes = []
         self._selected_edges = []
 
+        # 网格平铺纹理缓存（键：间距档位 / 颜色 / DPR）
+        self._grid_tile_cache = None
+        self._grid_tile_key = None
+
         # 交互状态
         self._panning = False
         self._pan_start = QPointF()
@@ -96,10 +106,20 @@ class BlueprintCanvas(QWidget):
         self._wire_src = None      # (node_id, Pin)
         self._wire_target = None   # (node_id, Pin)
         self._pending_wire = None  # 菜单创建后自动连接用
+        # 视图手势（平移 / 滚轮缩放）中跳过的节点几何落位待补偿标记
+        self._gesture_deferred = False
 
         self._flow_timer = QTimer(self)
         self._flow_timer.setInterval(50)
         self._flow_timer.timeout.connect(self._tick_flow)
+
+        # 滚轮缩放手势标记：手势期间 GL 代理节点位图按纹理缩放（不重建
+        # 缓存），手势结束 150ms 后触发一次全量重建恢复清晰
+        self._zooming = False
+        self._zoom_settle = QTimer(self)
+        self._zoom_settle.setSingleShot(True)
+        self._zoom_settle.setInterval(150)
+        self._zoom_settle.timeout.connect(self._end_zoom_gesture)
 
         self._execution = ExecutionController(self)
 
@@ -107,6 +127,12 @@ class BlueprintCanvas(QWidget):
         self.setFocusPolicy(Qt.StrongFocus)
         self.setMinimumSize(320, 240)
         self.setAttribute(Qt.WA_OpaquePaintEvent, True)
+
+        # 绘制视口：GL 可用时为 QOpenGLWidget（GPU 加速），否则软件回退；
+        # 与画布 1:1 重合（resizeEvent 同步几何），节点控件挂在其下。
+        self._viewport = create_viewport(self)
+        self._viewport.setGeometry(self.rect())
+        self._viewport.show()
 
         graph.node_added.connect(self._on_node_added)
         graph.node_removed.connect(self._on_node_removed)
@@ -153,6 +179,10 @@ class BlueprintCanvas(QWidget):
         self._zoom = z
         self._offset = QPointF(self.width() / 2, self.height() / 2) - center_scene * z
         self._update_view()
+        # 程序化连续缩放同样按手势处理：期间节点缓存位图拉伸显示，
+        # 停顿 150ms 后统一重建（避免每帧全量离屏重渲染）
+        self._zooming = True
+        self._zoom_settle.start()
 
     def zoom(self) -> float:
         """当前缩放系数。"""
@@ -266,7 +296,7 @@ class BlueprintCanvas(QWidget):
     # 图信号 → 界面同步
     # ------------------------------------------------------------------
     def _on_node_added(self, node: BlueprintNode) -> None:
-        widget = NodeWidget(node, self, owner=self._owner)
+        widget = NodeWidget(node, self._viewport, owner=self._owner)
         widget.installEventFilter(self)
         for pin in node.inputs + node.outputs:
             handle = widget.pin_widget(pin.id, pin.direction)
@@ -320,6 +350,31 @@ class BlueprintCanvas(QWidget):
             if node is not None:
                 widget.apply_view(self.scene_to_view(node.pos), self._zoom)
         self.update()
+
+    def _view_changed(self, gesture: bool = False) -> None:
+        """视图变换（zoom / offset 变化）后的界面同步。
+
+        ``gesture=True``（平移拖拽 / 滚轮缩放进行中）且视口支持节点位图
+        代理时：跳过逐节点几何落位，仅重绘视口——代理节点由视口按场景
+        坐标实时绘制，视觉不受控件几何滞后影响；带可见自定义体的节点
+        照常逐帧落位。被跳过的几何在手势结束时由 ``_settle_view_gesture``
+        统一补偿（引脚热区 / 子控件位置随即恢复精确）。
+        """
+        if gesture and getattr(self._viewport, "supports_node_proxy", False):
+            self._gesture_deferred = True
+            for widget in self._node_widgets.values():
+                if not widget.uses_proxy():
+                    widget.apply_view(self.scene_to_view(widget.node.pos),
+                                      self._zoom)
+            self.update()
+            return
+        self._update_view()
+
+    def _settle_view_gesture(self) -> None:
+        """视图手势结束（平移释放 / 缩放防抖到点）：补偿节点几何落位。"""
+        if self._gesture_deferred:
+            self._gesture_deferred = False
+            self._update_view()
 
     # ------------------------------------------------------------------
     # 选择
@@ -459,15 +514,34 @@ class BlueprintCanvas(QWidget):
         if not self._drag_moved and delta.manhattanLength() * self._zoom < 2.0:
             return
         self._drag_moved = True
+        defer = bool(getattr(self._viewport, "supports_node_proxy", False))
+        # 受影响边（两端任一在被拖节点上）的旧包围盒仅软件模式的局部
+        # 重绘需要；GL 代理模式整幅重绘，跳过该统计开销
+        affected = []
+        old_rects = []
+        if not defer:
+            for nid in starts:
+                for e in self.graph.edges_of(nid):
+                    ew = self._edge_widgets.get(e.id)
+                    if ew is not None and ew not in affected:
+                        affected.append(ew)
+                        old_rects.append(ew.bounding_rect())
         for nid, start_pos in starts.items():
             node = self.graph.node(nid)
             if node is None:
                 continue
             node.pos = start_pos + delta
             w = self._node_widgets.get(nid)
-            if w is not None:
+            # 位图代理节点由视口按场景坐标实时绘制，拖动期间无需逐帧落位
+            if w is not None and not (defer and w.uses_proxy()):
                 w.apply_view(self.scene_to_view(node.pos), self._zoom)
-        self.update()
+        if defer:
+            self._gesture_deferred = True
+            self.update()
+        else:
+            # 局部重绘：边的新旧包围盒即可（节点控件自行随几何移动重绘）
+            self._update_scene_rects(
+                old_rects + [ew.bounding_rect() for ew in affected])
 
     def _end_drag(self) -> None:
         start_view, starts = self._drag
@@ -478,6 +552,8 @@ class BlueprintCanvas(QWidget):
                 if node is not None:
                     self.node_moved.emit(nid, QPointF(node.pos))
         self._drag_moved = False
+        # 拖动中跳过的代理节点几何落位补偿（引脚热区恢复精确）
+        self._settle_view_gesture()
 
     # ------------------------------------------------------------------
     # 连线（引脚拖拽）
@@ -491,9 +567,24 @@ class BlueprintCanvas(QWidget):
                               parent=self)
         self._wire_src = (node.id, pin)
         self._wire_target = None
-        self.update()
+        self._update_scene_rects([self._wire_scene_rect(self._wire)])
+
+    def _wire_scene_rect(self, wire: TempWire) -> QRectF:
+        """临时线（含端点小圆点与描边余量）的场景包围盒。"""
+        r = bezier_path(wire.start, wire.end).boundingRect()
+        return r.adjusted(-12.0, -12.0, 12.0, 12.0)
+
+    def _wire_ring_rect(self, target) -> QRectF:
+        """磁吸高亮圈的场景包围盒（无目标时返回空矩形）。"""
+        if target is None:
+            return QRectF()
+        nid, pin = target
+        c = self.pin_scene_pos(nid, pin.id, pin.direction)
+        return QRectF(c - QPointF(12.0, 12.0), QSizeF(24.0, 24.0))
 
     def _update_wire(self, view_pos: QPointF) -> None:
+        old_rects = [self._wire_scene_rect(self._wire),
+                     self._wire_ring_rect(self._wire_target)]
         scene_pt = self.view_to_scene(view_pos)
         self._wire.set_end(scene_pt)
         self._wire_target = self._find_compatible_pin(scene_pt)
@@ -501,18 +592,26 @@ class BlueprintCanvas(QWidget):
         if self._wire_target is not None:
             nid, pin = self._wire_target
             self._wire.set_end(self.pin_scene_pos(nid, pin.id, pin.direction))
-        self.update()
+        self._update_scene_rects(
+            old_rects + [self._wire_scene_rect(self._wire),
+                         self._wire_ring_rect(self._wire_target)])
 
     def _find_compatible_pin(self, scene_pt: QPointF):
-        """在磁吸半径内找最近的兼容引脚（方向相反 + 类型兼容 + 非本节点）。"""
+        """在磁吸半径内找最近的兼容引脚（方向相反 + 类型兼容 + 非本节点）。
+
+        先用节点场景矩形对探测半径做粗筛，跳过远处节点的逐引脚计算。
+        """
         src_nid, src_pin = self._wire_src
         want_dir = (PinDirection.Input if src_pin.direction is PinDirection.Output
                     else PinDirection.Output)
         radius = MAGNET_R / self._zoom
+        probe = QRectF(scene_pt, scene_pt).adjusted(-radius, -radius, radius, radius)
         best = None
         best_d = radius
         for nid, widget in self._node_widgets.items():
             if nid == src_nid:
+                continue
+            if not probe.intersects(QRectF(widget.node.pos, widget.node.size)):
                 continue
             pins = widget.node.inputs if want_dir is PinDirection.Input else widget.node.outputs
             for pin in pins:
@@ -533,9 +632,12 @@ class BlueprintCanvas(QWidget):
         src_nid, src_pin = self._wire_src
         target = self._find_compatible_pin(self.view_to_scene(view_pos))
         wire, self._wire, self._wire_src, self._wire_target = self._wire, None, None, None
+        dirty = []
         if wire is not None:
+            dirty.append(self._wire_scene_rect(wire))
             wire.deleteLater()
         if target is not None:
+            dirty.append(self._wire_ring_rect(target))
             tgt_nid, tgt_pin = target
             if src_pin.direction is PinDirection.Output:
                 self.graph.add_edge(src_nid, src_pin.id, tgt_nid, tgt_pin.id)
@@ -551,7 +653,8 @@ class BlueprintCanvas(QWidget):
             menu.type_chosen.connect(self._create_node_for_wire)
             menu.popup_at(self.mapToGlobal(QPoint(int(view_pos.x()), int(view_pos.y()))),
                           compatible=(want_dir, src_pin.data_type))
-        self.update()
+        if dirty:
+            self._update_scene_rects(dirty)
 
     def _create_node_for_wire(self, type_name: str) -> None:
         """拖线松开菜单回调：创建节点并自动连接对应引脚。"""
@@ -615,7 +718,7 @@ class BlueprintCanvas(QWidget):
             return
         if self._panning:
             self._offset = self._offset_start + (pos - self._pan_start)
-            self._update_view()
+            self._view_changed(gesture=True)
             return
         if self._rpress is not None and event.buttons() & Qt.RightButton:
             start, _target = self._rpress
@@ -624,11 +727,14 @@ class BlueprintCanvas(QWidget):
                 self.setCursor(Qt.ClosedHandCursor)
             if self._rpan:
                 self._offset = self._offset_start + (pos - self._pan_start)
-                self._update_view()
+                self._view_changed(gesture=True)
             return
         if self._band is not None:
+            old_rect = QRectF(self._band[0], self._band[1]).normalized()
             self._band = (self._band[0], pos)
-            self.update()
+            new_rect = QRectF(self._band[0], self._band[1]).normalized()
+            dirty = old_rect.united(new_rect).adjusted(-3.0, -3.0, 3.0, 3.0)
+            self.update(dirty.toAlignedRect().intersected(self.rect()))
             return
         self._update_edge_hover(self.view_to_scene(pos))
         super().mouseMoveEvent(event)
@@ -641,11 +747,13 @@ class BlueprintCanvas(QWidget):
         if event.button() == Qt.MiddleButton and self._panning:
             self._panning = False
             self.unsetCursor()
+            self._settle_view_gesture()
             return
         if event.button() == Qt.LeftButton:
             if self._panning:
                 self._panning = False
                 self.unsetCursor()
+                self._settle_view_gesture()
                 return
             if self._band is not None:
                 self._finish_band()
@@ -657,6 +765,7 @@ class BlueprintCanvas(QWidget):
             if was_pan:
                 self._panning = False
                 self.unsetCursor()
+                self._settle_view_gesture()
             else:
                 scene_pt = self.view_to_scene(pos)
                 menu = NodeCreationMenu(self, owner=self._owner)
@@ -677,8 +786,16 @@ class BlueprintCanvas(QWidget):
         cursor = QPointF(event.position())
         self._offset = cursor - (cursor - self._offset) * (new_zoom / self._zoom)
         self._zoom = new_zoom
-        self._update_view()
+        self._view_changed(gesture=True)
+        self._zooming = True
+        self._zoom_settle.start()
         event.accept()
+
+    def _end_zoom_gesture(self) -> None:
+        """滚轮缩放手势结束：补偿几何落位并触发节点缓存按最终缩放重建。"""
+        self._zooming = False
+        self._settle_view_gesture()
+        self.update()
 
     def keyPressEvent(self, event) -> None:
         if event.key() == Qt.Key_Space and not event.isAutoRepeat():
@@ -739,14 +856,14 @@ class BlueprintCanvas(QWidget):
 
     def _update_edge_hover(self, scene_pt: QPointF) -> None:
         hit = self._edge_at(scene_pt)
-        changed = False
+        rects = []
         for eid, ew in self._edge_widgets.items():
             want = eid == hit
             if ew.hovered != want:
                 ew.hovered = want
-                changed = True
-        if changed:
-            self.update()
+                rects.append(ew.bounding_rect())
+        if rects:
+            self._update_scene_rects(rects)
 
     # -- 节点右键菜单 ------------------------------------------------------
     def _open_node_menu(self, widget: NodeWidget, global_pos: QPoint) -> None:
@@ -780,26 +897,69 @@ class BlueprintCanvas(QWidget):
 
     def _tick_flow(self) -> None:
         any_flowing = False
+        rects = []
         for ew in self._edge_widgets.values():
             if ew.flowing:
                 ew.advance_dash()
+                rects.append(ew.bounding_rect())
                 any_flowing = True
         if not any_flowing:
             self._flow_timer.stop()
-        self.update()
+            return
+        # 仅重绘流动边的包围盒（原实现为全画布重绘）
+        self._update_scene_rects(rects)
 
     # ------------------------------------------------------------------
-    # 绘制
+    # 绘制（由内部视口承载，见 viewport.py）
     # ------------------------------------------------------------------
     def paintEvent(self, _event) -> None:
+        # 画布本体被视口 1:1 覆盖；此处仅在视口尚未就位时兜底填底。
         p = QPainter(self)
-        p.setRenderHint(QPainter.Antialiasing)
+        p.fillRect(self.rect(), QColor(str(T("color.bg.base"))))
+        p.end()
+
+    def resizeEvent(self, event) -> None:
+        """视口几何同步：始终与画布 1:1 重合。"""
+        vp = getattr(self, "_viewport", None)
+        if vp is not None:
+            vp.setGeometry(self.rect())
+        super().resizeEvent(event)
+
+    def update(self, *args) -> None:
+        """重绘请求转发到内部绘制视口（保持外部 ``canvas.update()`` 习惯）。
+
+        Qt 内部对画布自身的 C++ 级 update 不受影响（画布只兜底填底）。
+        """
+        vp = getattr(self, "_viewport", None)
+        if vp is not None:
+            vp.update(*args)
+        else:
+            super().update(*args)
+
+    def _paint_contents(self, p: QPainter, dirty_view: QRect = None) -> None:
+        """画布全部自绘内容：背景 / 网格 / 选中发光 / 边 / 临时线 / 框选。
+
+        参数:
+            p: 目标画笔（控件坐标系，调用方已开抗锯齿）。
+            dirty_view: 局部重绘脏矩形（控件坐标）；``None`` 表示整幅。
+                边按包围盒与脏矩形求交做视口裁剪。
+        """
         p.fillRect(self.rect(), QColor(str(T("color.bg.base"))))
         self._draw_grid(p)
+        self._draw_selection_glow(p)
+        if dirty_view is not None and not dirty_view.isNull():
+            tl = self.view_to_scene(QPointF(dirty_view.topLeft()))
+            br = self.view_to_scene(QPointF(dirty_view.bottomRight()))
+        else:
+            tl = self.view_to_scene(QPointF(0.0, 0.0))
+            br = self.view_to_scene(QPointF(self.width(), self.height()))
+        dirty_scene = QRectF(tl, br).normalized()
         p.save()
         p.translate(self._offset)
         p.scale(self._zoom, self._zoom)
         for ew in self._edge_widgets.values():
+            if not ew.bounding_rect().intersects(dirty_scene):
+                continue
             ew.draw(p)
         if self._wire is not None:
             self._wire.draw(p)
@@ -820,26 +980,98 @@ class BlueprintCanvas(QWidget):
             p.setPen(QPen(border, 1.2))
             p.setBrush(fill)
             p.drawRect(rect)
-        p.end()
+
+    def _update_scene_rects(self, scene_rects) -> None:
+        """按场景坐标矩形列表请求局部重绘（换算视图坐标并合并求并集）。"""
+        rect = None
+        for r in scene_rects:
+            if r is None or r.isNull():
+                continue
+            vr = QRectF(self.scene_to_view(r.topLeft()),
+                        self.scene_to_view(r.bottomRight())).normalized()
+            vr = vr.adjusted(-2.0, -2.0, 2.0, 2.0)
+            rect = vr if rect is None else rect.united(vr)
+        if rect is not None:
+            self.update(rect.toAlignedRect().intersected(self.rect()))
+
+    def _draw_selection_glow(self, p: QPainter) -> None:
+        """选中节点的 shadow.md 外发光（画布层自绘，替代 QGraphicsEffect）。
+
+        以多层递增外扩的圆角描边逼近高斯模糊：透明度由近及远递减。
+        绘制顺序在网格之上、边与节点之下（与节点控件下方投影视觉等价）。
+        """
+        if not self._selected_nodes:
+            return
+        spec = ThemeManager.instance().tokens["shadow.md"]
+        r, g, b, a = spec["color"]
+        blur = float(spec["blur"])
+        ox, oy = spec["offset"]
+        steps = max(3, int(blur / 2))
+        base_radius = float(T("radius.lg")) * self._zoom
+        p.setBrush(Qt.NoBrush)
+        for nid in self._selected_nodes:
+            node = self.graph.node(nid)
+            if node is None:
+                continue
+            tl = self.scene_to_view(node.pos)
+            rect = QRectF(tl, QSizeF(node.size.width() * self._zoom,
+                                     node.size.height() * self._zoom))
+            rect.translate(float(ox), float(oy))
+            for i in range(steps):
+                t = (i + 0.5) / steps
+                grow = t * blur * 0.75
+                alpha = int(a * (1.0 - t) * 0.9)
+                if alpha <= 0:
+                    continue
+                pen = QPen(QColor(r, g, b, alpha), max(1.0, blur / steps + 0.5))
+                p.setPen(pen)
+                rr = rect.adjusted(-grow, -grow, grow, grow)
+                rad = base_radius + grow
+                p.drawRoundedRect(rr, rad, rad)
+
+    # ------------------------------------------------------------------
+    # 网格（平铺纹理缓存）
+    # ------------------------------------------------------------------
+    def _grid_tile(self, step_px: float) -> QPixmap:
+        """网格平铺块（按 间距档位 / 颜色 / DPR 缓存）。
+
+        块内四角各绘 1/4 圆点，平铺拼接后每个网格交叉点合成完整圆点，
+        替代逐点 ``drawEllipse`` 的双层循环（4K 下约 1.4 万次/帧）。
+        """
+        dpr = self.devicePixelRatioF()
+        si = max(2, int(round(step_px)))
+        color = QColor(str(T("color.border")))
+        key = (si, color.rgba(), dpr)
+        if self._grid_tile_key == key and self._grid_tile_cache is not None:
+            return self._grid_tile_cache
+        pm = QPixmap(max(1, int(si * dpr + 0.5)), max(1, int(si * dpr + 0.5)))
+        pm.setDevicePixelRatio(dpr)
+        pm.fill(Qt.transparent)
+        tp = QPainter(pm)
+        tp.setRenderHint(QPainter.Antialiasing)
+        tp.setPen(Qt.NoPen)
+        tp.setBrush(color)
+        side = pm.width() / dpr
+        for cx, cy in ((0.0, 0.0), (side, 0.0), (0.0, side), (side, side)):
+            tp.drawEllipse(QPointF(cx, cy), GRID_DOT_R, GRID_DOT_R)
+        tp.end()
+        self._grid_tile_key = key
+        self._grid_tile_cache = pm
+        return pm
 
     def _draw_grid(self, p: QPainter) -> None:
-        """点阵网格：间距随缩放自适应（屏幕间距保持在 18–72px 之间）。"""
+        """点阵网格：间距随缩放自适应（屏幕间距保持在 18–72px 之间）。
+
+        以缓存平铺纹理一次性铺满（brush 原点跟随 offset 相位）。
+        """
         step = 24.0
         while step * self._zoom < 18.0:
             step *= 2.0
         while step * self._zoom > 72.0:
             step /= 2.0
-        color = QColor(str(T("color.border")))
+        tile = self._grid_tile(step * self._zoom)
+        side = tile.width() / tile.devicePixelRatioF()
         p.setPen(Qt.NoPen)
-        p.setBrush(color)
-        w, h = self.width(), self.height()
-        x0 = self._offset.x() % (step * self._zoom)
-        y0 = self._offset.y() % (step * self._zoom)
-        r = 1.3
-        y = y0
-        while y <= h:
-            x = x0
-            while x <= w:
-                p.drawEllipse(QPointF(x, y), r, r)
-                x += step * self._zoom
-            y += step * self._zoom
+        p.setBrush(QBrush(tile))
+        p.setBrushOrigin(QPointF(self._offset.x() % side, self._offset.y() % side))
+        p.drawRect(self.rect())

--- a/InstructionX_UIKit/blueprint/edge_widget.py
+++ b/InstructionX_UIKit/blueprint/edge_widget.py
@@ -49,6 +49,9 @@ class EdgeWidget(QObject):
 
     状态属性：
         ``hovered`` / ``selected`` / ``flowing``（running 路径流动虚线）。
+
+    性能要点：贝塞尔路径 / 包围盒 / 命中采样点 / 基础颜色全部按端点
+    坐标缓存（端点变化时惰性重建），避免每帧 / 每次命中检测重建路径。
     """
 
     def __init__(self, canvas, edge, parent=None):
@@ -59,6 +62,15 @@ class EdgeWidget(QObject):
         self.selected = False
         self.flowing = False
         self._dash_offset = 0.0
+        # 几何缓存（端点几何键未变时零重建；见 _ensure_path）
+        self._geo_key = None
+        self._path = None
+        self._p1 = None
+        self._p2 = None
+        self._bounds = None
+        self._samples = None
+        # 基础颜色（边的引脚类型创建后不变，惰性取一次）
+        self._base_color = None
 
     # -- 几何 ------------------------------------------------------------
     def source_pos(self) -> QPointF:
@@ -73,26 +85,89 @@ class EdgeWidget(QObject):
         return self.canvas.pin_scene_pos(self.edge.to_node, self.edge.to_pin,
                                          PinDirection.Input)
 
+    def _ensure_path(self) -> None:
+        """端点几何变化时重建路径并级联失效派生缓存。
+
+        几何键 = 两端节点场景坐标 + 两端节点布局版本（引脚逻辑偏移随
+        布局变化）。键未变时每帧仅付两次 dict 查找与元组比较，不再走
+        ``pin_scene_pos`` → ``pin_logical_center`` 的完整解析链。
+        """
+        canvas = self.canvas
+        src = canvas.graph.node(self.edge.from_node)
+        tgt = canvas.graph.node(self.edge.to_node)
+        sw = canvas._node_widgets.get(self.edge.from_node)
+        tw = canvas._node_widgets.get(self.edge.to_node)
+        key = (
+            None if src is None else (
+                src.pos.x(), src.pos.y(),
+                sw._layout_rev if sw is not None else -1),
+            None if tgt is None else (
+                tgt.pos.x(), tgt.pos.y(),
+                tw._layout_rev if tw is not None else -1),
+        )
+        if self._path is not None and key == self._geo_key:
+            return
+        self._geo_key = key
+        self._p1, self._p2 = self.source_pos(), self.target_pos()
+        self._path = bezier_path(self._p1, self._p2)
+        self._bounds = None
+        self._samples = None
+
     def path(self) -> QPainterPath:
-        """当前贝塞尔曲线路径（场景坐标）。"""
-        return bezier_path(self.source_pos(), self.target_pos())
+        """当前贝塞尔曲线路径（场景坐标，缓存）。"""
+        self._ensure_path()
+        return self._path
 
     def bounding_rect(self) -> QRectF:
-        """路径外接矩形（含描边余量，场景坐标）。"""
-        return self.path().boundingRect().adjusted(-8, -8, 8, 8)
+        """路径外接矩形（含描边余量，场景坐标，缓存）。"""
+        self._ensure_path()
+        if self._bounds is None:
+            self._bounds = self._path.boundingRect().adjusted(-8, -8, 8, 8)
+        return self._bounds
 
     def contains(self, scene_pt: QPointF, tol: float = 7.0) -> bool:
-        """命中检测：场景点距曲线采样点的最小距离小于 ``tol`` 即命中。"""
-        path = self.path()
-        for pt in _path_points(path):
+        """命中检测：场景点距曲线采样点的最小距离小于 ``tol`` 即命中。
+
+        先做包围盒粗筛（含容差），通过后才比对缓存的曲线采样点。
+        """
+        coarse = self.bounding_rect().adjusted(-tol, -tol, tol, tol)
+        if not coarse.contains(scene_pt):
+            return False
+        self._ensure_path()
+        if self._samples is None:
+            self._samples = _path_points(self._path)
+        for pt in self._samples:
             if math.hypot(pt.x() - scene_pt.x(), pt.y() - scene_pt.y()) <= tol:
                 return True
         return False
 
+    def _color(self) -> QColor:
+        """边的基础颜色（按源引脚类型，惰性缓存）。"""
+        if self._base_color is None:
+            from .model import PinDirection
+            node = self.canvas.graph.node(self.edge.from_node)
+            pin = (node.pin(self.edge.from_pin, PinDirection.Output)
+                   if node is not None else None)
+            self._base_color = (QColor(pin_color(pin.data_type)) if pin is not None
+                                else QColor(str(T("color.text.tertiary"))))
+        return QColor(self._base_color)
+
     # -- 状态 ------------------------------------------------------------
     def set_flowing(self, on: bool) -> None:
-        """设置 / 取消流动虚线动画（由 ExecutionController.set_path 驱动）。"""
-        self.flowing = bool(on)
+        """设置 / 取消流动虚线动画（由 ExecutionController.set_path 驱动）。
+
+        状态翻转时请求画布局部重绘本边包围盒，确保流动虚线及时出现 /
+        清除（画布定时器只负责推进相位，不负责状态翻转后的首帧）。
+        """
+        on = bool(on)
+        if on == self.flowing:
+            return
+        self.flowing = on
+        update = getattr(self.canvas, "_update_scene_rects", None)
+        if update is not None:
+            update([self.bounding_rect()])
+        else:
+            self.canvas.update()
 
     def advance_dash(self, step: float = 1.6) -> None:
         """推进流动虚线相位（画布定时器调用）。"""
@@ -101,13 +176,7 @@ class EdgeWidget(QObject):
     # -- 绘制 ------------------------------------------------------------
     def draw(self, p: QPainter) -> None:
         """在已做场景变换的画笔上绘制本条边（抗锯齿、主题实时取色）。"""
-        from .model import PinDirection
         path = self.path()
-        node = self.canvas.graph.node(self.edge.from_node)
-        pin = (node.pin(self.edge.from_pin, PinDirection.Output)
-               if node is not None else None)
-        base = QColor(pin_color(pin.data_type)) if pin is not None else QColor(
-            str(T("color.text.tertiary")))
         if self.flowing:
             color = QColor(str(T("color.primary")))
             pen = QPen(color, 2.4)
@@ -120,7 +189,7 @@ class EdgeWidget(QObject):
             p.drawPath(path)
             return
         width = 2.0
-        color = base
+        color = self._color()
         if self.selected:
             color = QColor(str(T("color.primary")))
             width = 2.8

--- a/InstructionX_UIKit/blueprint/node_widget.py
+++ b/InstructionX_UIKit/blueprint/node_widget.py
@@ -8,7 +8,7 @@
 - 自定义体区：``NodeSpec.body_builder`` 注入；缺省显示 properties 键值；
 - 状态视觉：running = 标题栏 SpinnerArc + accent 脉冲描边；
   done = success 2px 描边 + 耗时徽标胶囊；error = danger 描边 + 错误图标；
-  选中 = primary 2px 描边 + shadow.md。
+  选中 = primary 2px 描边 + shadow.md 外发光（外发光由画布层自绘）。
 
 实现要点（供维护者参考）：
 
@@ -28,7 +28,7 @@ from PySide6.QtGui import QColor, QFont, QPainter, QPainterPath, QPen
 from PySide6.QtWidgets import QFrame, QVBoxLayout, QWidget
 
 from ..anim.painted import SpinnerArc
-from ..theme import T, ThemeManager, apply_shadow
+from ..theme import T, ThemeManager
 from .model import BlueprintNode, PinDirection
 from .registry import NodeRegistry, pin_color
 
@@ -138,7 +138,7 @@ class NodeWidget(QFrame):
 
     供画布使用的接口：
         ``pin_widget(pin_id)``：取引脚热区控件（用于全局坐标 / 事件）；
-        ``set_selected(bool)``：选中态（primary 描边 + shadow.md）；
+        ``set_selected(bool)``：选中态（primary 描边，外发光由画布绘制）；
         ``apply_view(scene_pos, scale)``：由画布按视图变换放置；
         ``badge_rect()``：done 耗时徽标的逻辑矩形（测试像素断言用）；
         ``elapsed_text()``：当前耗时徽标文本。
@@ -155,6 +155,15 @@ class NodeWidget(QFrame):
         self._spinner = None
         self._pulse = 0.0
         self._body_h = 0.0
+        # 外观位图缓存（GL 视口代理绘制用；仅 GL 模式生效）
+        self._cache_pm = None
+        self._cache_scale = 0.0
+        self._cache_dirty = True
+        # 布局版本与引脚逻辑坐标缓存（_relayout 重建；边端点几何键使用）
+        self._layout_rev = 0
+        self._pin_offsets = {}
+        # GL 位图代理状态缓存（_relayout 重算；见 uses_proxy）
+        self._proxy_state = False
         _transparent(self)
         self.setAttribute(Qt.WA_StyledBackground, False)
         self.setMouseTracking(True)
@@ -245,6 +254,20 @@ class NodeWidget(QFrame):
         w = max(MIN_W, tw, pin_w, body_w)
         h = TITLE_H + rows * PIN_ROW_H + self._body_h + PAD_BOTTOM
         self.node.size = QSizeF(w, h)
+        # 引脚逻辑坐标缓存 + 布局版本（边端点几何键 / 高频查询用）
+        self._pin_offsets = {}
+        for i, pin in enumerate(self.node.inputs):
+            self._pin_offsets[(PinDirection.Input, pin.id)] = QPointF(
+                0.0, TITLE_H + i * PIN_ROW_H + PIN_ROW_H / 2)
+        for i, pin in enumerate(self.node.outputs):
+            self._pin_offsets[(PinDirection.Output, pin.id)] = QPointF(
+                w, TITLE_H + i * PIN_ROW_H + PIN_ROW_H / 2)
+        self._layout_rev += 1
+        # 位图代理状态：父视口支持代理且无可见自定义体（_relayout 时机与
+        # 体可见性翻转一致，见 apply_view 的 BODY_MIN_ZOOM 处理）
+        self._proxy_state = (
+            getattr(self.parentWidget(), "supports_node_proxy", False)
+            and not self._body_visible())
         self._arrange_children()
 
     def _arrange_children(self) -> None:
@@ -265,7 +288,11 @@ class NodeWidget(QFrame):
                                   int((TITLE_H * s - ss) / 2), int(ss), int(ss))
 
     def pin_logical_center(self, pin) -> QPointF:
-        """引脚圆心的节点逻辑坐标（输入在左缘、输出在右缘）。"""
+        """引脚圆心的节点逻辑坐标（输入在左缘、输出在右缘，布局缓存）。"""
+        c = self._pin_offsets.get((pin.direction, pin.id))
+        if c is not None:
+            return QPointF(c)
+        # 回退：布局缓存尚未建立时的直接计算
         w = self.node.size.width()
         if pin.direction is PinDirection.Input:
             idx = self.node.inputs.index(pin)
@@ -305,18 +332,82 @@ class NodeWidget(QFrame):
         self.update()
 
     # ------------------------------------------------------------------
+    # GL 代理绘制（位图缓存）
+    # ------------------------------------------------------------------
+    def uses_proxy(self) -> bool:
+        """当前是否由 GL 视口以位图缓存代理绘制。
+
+        条件：父控件是支持代理的视口（``supports_node_proxy``，即
+        ``_GLViewport``），且自定义体（body_builder 注入的真实控件）
+        当前不可见。带可见体的节点保持真实控件自绘（兼容性边界）。
+
+        结果为 ``_relayout`` 时重算的缓存（体可见性翻转必然伴随
+        ``_relayout``，见 ``apply_view``），高频调用零开销。
+        """
+        return bool(self._proxy_state)
+
+    def _invalidate_cache(self) -> None:
+        """内容 / 状态 / 主题变化后标记缓存失效（下次取缓存时重建）。"""
+        self._cache_dirty = True
+
+    def cache_pixmap(self) -> "QPixmap":
+        """外观缓存位图（惰性重建；缩放手势中沿用旧位图纹理缩放）。
+
+        重建时机：缓存缺失 / 标记失效 / 缩放系数变化且不在滚轮缩放手势
+        进行中（手势期间由视口按目标矩形拉伸旧位图，手势结束 150ms 后
+        由画布触发一次全量重建，保证最终清晰）。
+        """
+        zooming = False
+        vp = self.parentWidget()
+        canvas = getattr(vp, "_canvas", None)
+        if canvas is not None:
+            zooming = bool(getattr(canvas, "_zooming", False))
+        if (self._cache_pm is None or self._cache_dirty
+                or (abs(self._cache_scale - self._scale) > 1e-3 and not zooming)):
+            self._render_cache()
+        return self._cache_pm
+
+    def _render_cache(self) -> None:
+        """把节点外观（逻辑坐标内容）离屏渲染为按 缩放 × DPR 的位图。"""
+        from PySide6.QtGui import QPixmap
+        s = self._scale
+        dpr = self.devicePixelRatioF()
+        w = self.node.size.width() * s * dpr
+        h = self.node.size.height() * s * dpr
+        pm = QPixmap(max(1, math.ceil(w)), max(1, math.ceil(h)))
+        pm.setDevicePixelRatio(dpr)
+        pm.fill(Qt.transparent)
+        p = QPainter(pm)
+        p.setRenderHint(QPainter.Antialiasing)
+        p.setRenderHint(QPainter.TextAntialiasing)
+        p.scale(s, s)
+        self._paint_content(p)
+        p.end()
+        self._cache_pm = pm
+        self._cache_scale = s
+        self._cache_dirty = False
+
+    def update(self, *args) -> None:
+        """代理模式下重绘请求转发给视口（自身透明，无需控件级重绘）。"""
+        if self.uses_proxy():
+            vp = self.parentWidget()
+            if vp is not None:
+                vp.update(self.geometry())
+            return
+        super().update(*args)
+
+    # ------------------------------------------------------------------
     # 选中 / 状态
     # ------------------------------------------------------------------
     def set_selected(self, on: bool) -> None:
-        """设置选中态：primary 2px 描边 + shadow.md（取消时移除阴影）。"""
+        """设置选中态：primary 2px 描边（本控件内）+ shadow.md 外发光
+        （由画布层自绘，避免 QGraphicsDropShadowEffect 的软件模糊开销）。
+        """
         on = bool(on)
         if on == self._selected:
             return
         self._selected = on
-        if on:
-            apply_shadow(self, "md")
-        else:
-            self.setGraphicsEffect(None)
+        self._invalidate_cache()
         self.update()
 
     def is_selected(self) -> bool:
@@ -363,28 +454,45 @@ class NodeWidget(QFrame):
             self.setToolTip(self.node.error_message)
         else:
             self.setToolTip("")
+        self._invalidate_cache()
         self.update()
 
     def _on_node_changed(self) -> None:
         self._relayout()
+        # 父控件可能是画布或画布内的绘制视口（viewport.py），逐级找落位回调
         parent = self.parentWidget()
-        if parent is not None and hasattr(parent, "_node_layout_changed"):
-            parent._node_layout_changed(self)
+        handler = getattr(parent, "_node_layout_changed", None)
+        if handler is None and parent is not None:
+            handler = getattr(parent.parentWidget(), "_node_layout_changed", None)
+        if handler is not None:
+            handler(self)
+        self._invalidate_cache()
         self.update()
 
     def _tick_pulse(self) -> None:
         self._pulse += 0.033
+        self._invalidate_cache()
         self.update()
 
     # ------------------------------------------------------------------
     # 绘制
     # ------------------------------------------------------------------
     def paintEvent(self, _event) -> None:
+        if self.uses_proxy():
+            return  # GL 视口代理绘制：自身仅作交互容器（子控件照常工作）
         p = QPainter(self)
         p.setRenderHint(QPainter.Antialiasing)
         p.setRenderHint(QPainter.TextAntialiasing)
-        s = self._scale
-        p.scale(s, s)
+        p.scale(self._scale, self._scale)
+        self._paint_content(p)
+        p.end()
+
+    def _paint_content(self, p: QPainter) -> None:
+        """节点外观全部内容（逻辑坐标；调用方已 scale 并开抗锯齿）。
+
+        供 ``paintEvent``（软件路径）与 ``_render_cache``（GL 位图缓存）
+        两条路径共用，保证两种渲染模式下外观一致。
+        """
         w, h = self.node.size.width(), self.node.size.height()
         radius = float(T("radius.lg"))
         accent = self.accent_color()
@@ -476,7 +584,6 @@ class NodeWidget(QFrame):
         p.setPen(QPen(border_color, border_w))
         p.setBrush(Qt.NoBrush)
         p.drawPath(path)
-        p.end()
 
     def _draw_pins(self, p: QPainter) -> None:
         """绘制引脚行：彩色圆点（multi 双环）+ 名称。"""
@@ -518,5 +625,6 @@ class NodeWidget(QFrame):
     # ------------------------------------------------------------------
     def refresh_theme(self) -> None:
         """主题切换时重排并重绘（画布 / 测试可直接调用）。"""
+        self._invalidate_cache()
         self._relayout()
         self.update()

--- a/InstructionX_UIKit/blueprint/viewport.py
+++ b/InstructionX_UIKit/blueprint/viewport.py
@@ -1,0 +1,207 @@
+# -*- coding: utf-8 -*-
+"""蓝图画布绘制视口（BP_SPEC §5 实现细节，GPU 加速承载层）。
+
+``BlueprintCanvas`` 保持 ``QWidget`` 基类与全部公共 API 不变；其自绘
+内容（背景 / 网格 / 选中发光 / 边 / 临时线 / 框选）由本模块的私有
+视口子控件承载，视口与画布 1:1 重合：
+
+- GL 可用：``_GLViewport(QOpenGLWidget)``——``paintGL`` 中以
+  ``QPainter`` 执行与软件路径**同一份**绘制代码（
+  ``BlueprintCanvas._paint_contents``），自动走 GL paint engine：
+  填充 / 纹理平铺 / 曲线由 GPU 承担，文本走字形纹理缓存；
+- GL 不可用（offscreen / minimal 测试环境、无 GL 驱动、
+  ``UIKIT_BLUEPRINT_GL=off``）：``_RasterViewport(QWidget)``，
+  行为与历史实现逐像素等价。
+
+GL 可用性由 ``gl_available()`` 运行时探测（模块级缓存，仅探测一次）：
+
+- 环境变量 ``UIKIT_BLUEPRINT_GL``：``auto``（默认）/ ``on``（强制
+  尝试，失败仍回退并记 WARNING）/ ``off``（强制软件渲染）；
+- offscreen / minimal 平台直接判不可用（实测该组合下 GL 上下文
+  无法创建）；
+- 其余平台试探创建 ``QOpenGLContext`` + ``QOffscreenSurface`` 并
+  ``makeCurrent``，任何一步失败即回退。
+
+节点控件（``NodeWidget`` 及其子控件）挂在视口之下：GL 模式下作为
+alien 子控件由 Qt 合成叠加在 GL 内容上（已实测验证）。鼠标 / 滚轮 /
+键盘事件由视口原样转发给画布既有处理器（坐标系一致，无需换算）。
+"""
+
+import logging
+import os
+
+from PySide6.QtGui import QGuiApplication, QPainter
+from PySide6.QtOpenGLWidgets import QOpenGLWidget
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QWidget
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["gl_available", "create_viewport"]
+
+#: GL 可用性探测结果（模块级缓存，``None`` 表示尚未探测）
+_GL_STATE = None
+
+
+def gl_available() -> bool:
+    """当前环境是否可用 GL 视口（结果缓存；受 ``UIKIT_BLUEPRINT_GL`` 控制）。"""
+    global _GL_STATE
+    if _GL_STATE is None:
+        _GL_STATE = _probe_gl()
+    return _GL_STATE
+
+
+def _probe_gl() -> bool:
+    """实际探测：环境变量 → 平台名 → 试探创建 GL 上下文。"""
+    env = os.environ.get("UIKIT_BLUEPRINT_GL", "auto").strip().lower()
+    if env == "off":
+        return False
+    app = QGuiApplication.instance()
+    if app is None:
+        return False
+    platform = app.platformName()
+    if platform in ("offscreen", "minimal", "minimalegl"):
+        if env == "on":
+            logger.warning(
+                "UIKIT_BLUEPRINT_GL=on 但平台 %s 不支持 GL，回退软件渲染", platform)
+        return False
+    try:
+        from PySide6.QtGui import QOffscreenSurface, QOpenGLContext
+        ctx = QOpenGLContext()
+        if not ctx.create():
+            raise RuntimeError("QOpenGLContext.create 失败")
+        surface = QOffscreenSurface()
+        surface.setFormat(ctx.format())
+        surface.create()
+        if not surface.isValid():
+            raise RuntimeError("QOffscreenSurface 创建失败")
+        if not ctx.makeCurrent(surface):
+            raise RuntimeError("QOpenGLContext.makeCurrent 失败")
+        ctx.doneCurrent()
+        return True
+    except Exception as exc:
+        if env == "on":
+            logger.warning(
+                "UIKIT_BLUEPRINT_GL=on 但 GL 探测失败（%s），回退软件渲染", exc)
+        return False
+
+
+class _ViewportMixin:
+    """视口公共行为：持有画布引用、转发交互事件（1:1 重合，坐标一致）。"""
+
+    def _init_viewport(self, canvas) -> None:
+        self._canvas = canvas
+        self.setMouseTracking(True)
+        self.setFocusPolicy(Qt.StrongFocus)
+        self.setAutoFillBackground(False)
+
+    # -- 事件转发（Qt 覆写，保留 camelCase） --------------------------------
+    def mousePressEvent(self, event) -> None:  # noqa: N802
+        self._canvas.mousePressEvent(event)
+
+    def mouseMoveEvent(self, event) -> None:  # noqa: N802
+        self._canvas.mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event) -> None:  # noqa: N802
+        self._canvas.mouseReleaseEvent(event)
+
+    def wheelEvent(self, event) -> None:  # noqa: N802
+        self._canvas.wheelEvent(event)
+
+    def keyPressEvent(self, event) -> None:  # noqa: N802
+        self._canvas.keyPressEvent(event)
+
+    def keyReleaseEvent(self, event) -> None:  # noqa: N802
+        self._canvas.keyReleaseEvent(event)
+
+
+class _RasterViewport(_ViewportMixin, QWidget):
+    """软件回退视口：普通 QWidget，paintEvent 走 CPU raster（历史行为）。
+
+    节点由真实子控件自绘（``supports_node_proxy = False``），保证
+    offscreen 测试的像素级行为与历史版本一致。
+    """
+
+    #: 不支持节点位图代理（节点自行 paintEvent）
+    supports_node_proxy = False
+
+    def __init__(self, canvas) -> None:
+        super().__init__(canvas)
+        self._init_viewport(canvas)
+        self.setAttribute(Qt.WA_OpaquePaintEvent, True)
+
+    def paintEvent(self, event) -> None:  # noqa: N802
+        p = QPainter(self)
+        p.setRenderHint(QPainter.Antialiasing)
+        self._canvas._paint_contents(p, event.rect())
+        p.end()
+
+
+class _GLViewport(_ViewportMixin, QOpenGLWidget):
+    """GPU 视口：QOpenGLWidget，paintGL 中 QPainter 自动走 GL paint engine。
+
+    GL 模式下不做脏矩形裁剪（QOpenGLWidget 默认整幅 FBO 重绘），
+    边的视口裁剪仍由 ``_paint_contents`` 按可见区域执行。
+
+    节点位图代理（``supports_node_proxy = True``）：无可见自定义体的
+    节点以 ``NodeWidget.cache_pixmap()`` 缓存位图由本视口统一绘制
+    （GL 纹理采样），平移 / 缩放手势期间节点内容零重绘；节点控件
+    本身保持透明，仅承担交互（引脚热区 / 拖动）与动态子控件
+    （SpinnerArc）的载体。带可见 ``body_builder`` 体的节点回退为
+    真实控件自绘（alien 子控件叠加）。
+    """
+
+    #: 支持节点位图代理绘制
+    supports_node_proxy = True
+
+    def __init__(self, canvas) -> None:
+        super().__init__(canvas)
+        self._init_viewport(canvas)
+
+    def paintGL(self) -> None:  # noqa: N802
+        p = QPainter(self)
+        p.setRenderHint(QPainter.Antialiasing)
+        self._canvas._paint_contents(p, None)
+        self._paint_proxied_nodes(p)
+        p.end()
+
+    def _paint_proxied_nodes(self, p: QPainter) -> None:
+        """按场景坐标实时绘制全部可见代理节点的缓存位图（节点在边之上）。
+
+        位置直接由 ``scene_to_view(node.pos)`` 计算而非读取控件几何：
+        视图手势（平移 / 滚轮缩放）期间画布会跳过逐节点几何落位
+        （见 ``BlueprintCanvas._view_changed``），此处仍保证视觉正确。
+        """
+        from PySide6.QtCore import QRectF, QPointF
+        p.setRenderHint(QPainter.SmoothPixmapTransform, True)
+        canvas = self._canvas
+        z = canvas._zoom
+        ox, oy = canvas._offset.x(), canvas._offset.y()
+        vw, vh = self.width(), self.height()
+        for w in canvas._node_widgets.values():
+            if not w.isVisible() or not w._proxy_state:
+                continue
+            node = w.node
+            # 内联浮点换算（scene_to_view 等价），避免逐节点 shiboken 开销
+            tx = node.pos.x() * z + ox
+            ty = node.pos.y() * z + oy
+            nw = node.size.width() * z
+            nh = node.size.height() * z
+            if tx > vw or ty > vh or tx + nw < 0 or ty + nh < 0:
+                continue
+            pm = w.cache_pixmap()
+            if abs(w._cache_scale - z) > 1e-3:
+                # 缩放手势中：旧位图按目标矩形拉伸（GPU 纹理缩放）
+                p.drawPixmap(QRectF(tx, ty, nw, nh), pm, QRectF(pm.rect()))
+            else:
+                p.drawPixmap(QPointF(tx, ty), pm)
+
+
+def create_viewport(canvas) -> QWidget:
+    """按 GL 可用性为画布创建绘制视口（调用方负责铺满与 show）。"""
+    if gl_available():
+        try:
+            return _GLViewport(canvas)
+        except Exception as exc:  # 防御：构造期异常同样回退
+            logger.warning("GL 视口创建失败，回退软件渲染: %s", exc)
+    return _RasterViewport(canvas)

--- a/demo/main_window.py
+++ b/demo/main_window.py
@@ -97,10 +97,26 @@ class MainWindow(QMainWindow):
         splitter.setCollapsible(1, False)
         root.addWidget(splitter, 1)
 
+        # 预热蓝图页：蓝图 GL 视口基于 QOpenGLWidget，若在顶层窗口可见之后
+        # 才加入窗口树，Qt 会重建顶层原生窗口句柄（表现为窗口短暂关闭重开）。
+        # 在 show() 之前的构造阶段创建蓝图页即可规避（USAGE.md §8.6）。
+        self._prewarm_blueprint()
+
         # 默认选中第一页
         first = self._first_leaf()
         if first is not None:
             self._tree.setCurrentItem(first)
+
+    def _prewarm_blueprint(self) -> None:
+        """在窗口显示前预创建蓝图演示页（不改变当前选中页）。"""
+        for i in range(self._tree.topLevelItemCount()):
+            cat = self._tree.topLevelItem(i)
+            for j in range(cat.childCount()):
+                child = cat.child(j)
+                data = child.data(0, Qt.UserRole)
+                if data is not None and data[0] == "blueprint":
+                    self.show_page(data[0], data[1])
+                    return
 
     # -- 顶部条 -----------------------------------------------------------
     def _build_topbar(self) -> QWidget:

--- a/demo/pages/blueprint.py
+++ b/demo/pages/blueprint.py
@@ -584,6 +584,9 @@ class BlueprintDemoPage(QWidget):
             item = lay.takeAt(0)
             w = item.widget()
             if w is not None:
+                # 先隐藏再摘出父级：setParent(None) 会让控件短暂成为可见的
+                # 顶层窗口（表现为闪弹一个游离小窗），hide 可避免。
+                w.hide()
                 w.setParent(None)
                 w.deleteLater()
         self.panel_form = None

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1154,7 +1154,21 @@ ex.reset()                        # 全部回 idle，清耗时与路径
 
 Demo 蓝图页的「运行」按 exec 链拓扑序用 QTimer 逐节点模拟（每节点 200–800ms 随机耗时），「单步」逐节点推进——全部只是状态指示，无业务逻辑。
 
-### 8.6 序列化
+### 8.6 渲染后端（GPU 加速）
+
+画布绘制由内部视口承载，**运行时自动选择后端，调用方无需修改任何代码**：
+
+- **GL 后端（默认，可用时）**：视口为 `QOpenGLWidget`，背景 / 网格 / 边 / 节点位图合成走 GPU；无可见自定义体（`body_builder`）的节点以缓存位图代理由视口统一绘制，平移 / 缩放 / 拖动期间节点内容零重绘，高分辨率（4K+）与大节点量场景显著流畅。带可见自定义体的节点自动回退为真实控件渲染。
+- **软件后端（自动回退）**：无 GL 环境（含 `QT_QPA_PLATFORM=offscreen` 的测试环境）时使用普通 QWidget 视口，行为与历史版本一致，离屏测试与截图回归不受影响。
+
+环境变量 `UIKIT_BLUEPRINT_GL` 可控制后端选择：`auto`（默认，自动探测）/ `on`（强制尝试，失败仍回退并记 WARNING）/ `off`（强制软件渲染，可用于排查显示问题）。
+
+```python
+import os
+os.environ["UIKIT_BLUEPRINT_GL"] = "off"   # 在 QApplication 创建前设置
+```
+
+### 8.7 序列化
 
 ```python
 data = canvas.to_dict()      # {"graph": {...}, "view": {"zoom", "offset"}}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1168,6 +1168,8 @@ import os
 os.environ["UIKIT_BLUEPRINT_GL"] = "off"   # 在 QApplication 创建前设置
 ```
 
+> **注意（GL 后端的 Qt 固有行为）**：`QOpenGLWidget` 加入**已可见**的顶层窗口时，Qt 会重建该窗口的原生句柄，表现为窗口短暂关闭后重开一次。建议像 Demo 的 `MainWindow` 一样，在顶层窗口 `show()` 之前创建 `BlueprintCanvas`（或至少预创建一次蓝图页面）；一次性创建并长期持有画布的应用不受影响。
+
 ### 8.7 序列化
 
 ```python
@@ -1178,7 +1180,7 @@ graph.to_dict()              # 仅数据层：{"nodes": [...], "edges": [...]}
 
 全部 JSON 友好（`json.dumps` 可直接序列化），含节点位置、引脚、properties 与画布 zoom/offset。
 
-### 8.7 应用场景
+### 8.8 应用场景
 
 节点图天然适合「可视化拼装 + 数据流」类工具：**PyTorch 模块拼装**（把 Conv / Attention / 融合等模块注册为节点类型，properties 承载超参数，图结构导出为构建脚本）、**着色器 / 材质流水线**（纹理输入、滤镜、混合节点，引脚类型映射数据格式）、**AI 流水线编排**（加载→预处理→推理→后处理→落盘，如 Demo 预置图），以及规则引擎、音视频转码链、ETL 流程等。库只负责编辑与状态展示，真正的执行调度由应用层按图拓扑自行实现。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "instructionx-uikit"
-# 项目版本号统一为 alpha-v1.0.0（见 InstructionX_UIKit.__version__）；
-# pyproject 受 PEP 440 限制，此处为其规范等价形式 1.0.0a1
-version = "1.0.0a1"
+# 项目版本号统一为 alpha-v1.0.1（见 InstructionX_UIKit.__version__）；
+# pyproject 受 PEP 440 限制，此处为其规范等价形式 1.0.1a1
+version = "1.0.1a1"
 description = "基于 PySide6 的纯桌面 UI 组件库：设计令牌双主题、57 组件、12 布局、52 动画、原生图表引擎与蓝图节点图"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "instructionx-uikit"
-version = "1.0.0a1"
+version = "1.0.1a1"
 source = { virtual = "." }
 dependencies = [
     { name = "pyside6" },


### PR DESCRIPTION
# InstructionX_UIKit alpha-v1.0.1

蓝图节点图 GPU 加速渲染版本。本次更新的核心是蓝图画布渲染后端重构：在保持**公共 API 完全不变**的前提下，引入 GPU 辅助绘制，显著改善高分辨率（4K+）与大节点量场景下的平移 / 缩放流畅度。已集成旧版本的项目**只需升级组件库，无需修改任何代码**。

## 亮点：蓝图画布 GPU 加速渲染

画布绘制改由内部视口承载，运行时自动选择后端：

- **GL 后端（默认，可用时）**：视口基于 `QOpenGLWidget`，背景 / 网格 / 连线 / 节点位图合成走 GPU。无可见自定义体（`body_builder`）的节点以缓存位图代理由视口统一绘制，平移 / 缩放 / 拖动期间节点内容零重绘；带可见自定义体的节点自动回退为真实控件渲染。
- **软件后端（自动回退）**：无 GL 环境（含 `QT_QPA_PLATFORM=offscreen` 的测试环境）自动使用普通 QWidget 视口，行为与历史版本完全一致，离屏测试与截图回归不受影响。
- 环境变量 `UIKIT_BLUEPRINT_GL` 可手动控制：`auto`（默认）/ `on`（强制尝试，失败回退并记 WARNING）/ `off`（强制软件渲染，可用于排查显示问题）。

配套绘制优化（两条后端同时受益）：

- 网格平铺纹理缓存；连线路径 / 包围盒 / 采样点缓存与视口裁剪、命中测试包围盒粗筛
- 节点选中发光改由画布层自绘（移除 `QGraphicsEffect`）；引脚坐标等热点数据缓存
- 拖动 / 悬停 / 框选 / 流动虚线改为局部重绘；视图手势期间跳过逐节点几何落位，手势结束统一补偿；滚轮缩放防抖

实测参考（1080p 窗口、300 节点 / 450 边，桌面 OpenGL 4.6）：

| 操作 | 优化前（纯 CPU） | 本版 GL 后端 |
|---|---|---|
| 画布平移 | 约 45 ms/帧 | 约 19 ms/帧 |
| 滚轮缩放 | 约 51 ms/帧 | 约 15 ms/帧 |

分辨率越高（4K+），GL 后端相对纯 CPU 绘制的优势越明显。

> **注意（Qt 固有行为）**：`QOpenGLWidget` 加入**已可见**的顶层窗口时，Qt 会重建该窗口的原生句柄，表现为窗口短暂关闭后重开一次。建议在顶层窗口 `show()` 之前创建 `BlueprintCanvas`（或预创建一次蓝图页面）；启动时一次性创建并长期持有画布的应用不受影响。详见 `docs/USAGE.md` §8.6。

## 新功能：蓝图节点注册表 owner 命名空间隔离

- 注册表键改为 `(owner, type_name)`：多个插件 / 模块可注册**同名节点类型**但引脚定义不同，互不干扰
- 注册、查询、创建均可携带 `owner` 关键字参数划定命名空间；`owner=None` 为全局命名空间，**不传 owner 的旧调用行为完全不变**
- 画布、创建菜单、节点体构造全链路支持 owner 透传；同空间异定义覆盖记 WARNING
- 详见 `docs/USAGE.md` §8.4；Demo 蓝图页已改为标准用法示范（`uikit-demo` 命名空间 + `other-plugin` 共存演示）

## 修复

- **依赖声明**：`pyproject.toml` 补充 `qrcode[pil]>=7.4`，与 `requirements.txt` 保持一致（Issue #2）
- **Demo 蓝图页**：修复选中节点时闪弹一个游离小窗口的问题（属性面板重建时控件被直接摘除父级、短暂成为可见顶层窗口）
- **Demo 主窗口**：修复首次切换到蓝图页时主窗口短暂关闭后重开的问题（蓝图页改为窗口显示前预创建）

## 兼容性

- 公共 API 零变化，旧项目直接升级即可
- 测试代码（`test` 分支）全部离屏通过：29 个测试脚本，含蓝图模块、75+ 演示页遍历与亮 / 暗截图回归